### PR TITLE
Update citation.rb to add new citation type options for book, journal or periodical and online encyclopedia

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -15,7 +15,7 @@
 
 ##
 # A Citation of an InfoRequest or InfoRequestBatch in news stories or an
-# academic paper
+# academic paper, a journal/periodical, an online encyclopedia or other document/publication.
 #
 class Citation < ApplicationRecord
   self.inheritance_column = nil
@@ -29,7 +29,7 @@ class Citation < ApplicationRecord
                                    message: _('Source URL is too long') },
                          format: { with: /\Ahttps?:\/\/.*\z/,
                                    message: _('Please enter a Source URL') }
-  validates :type, inclusion: { in: %w(news_story academic_paper other),
+  validates :type, inclusion: { in: %w(news_story academic_paper journal_or_periodical book online_encyclopedia other),
                                 message: _('Please select a type') }
 
   scope :newest, ->(limit = 1) do


### PR DESCRIPTION
Add new citation type options for book, journal or periodical and online encyclopedia.

## Relevant issue(s)
Numerous Wikipedia articles cite WhatDoTheyKnow but we don't have a suitable option for this apart from "other". It would be great to capture books separately. Some professions have journals that are not exactly academic papers.

## What does this do?
Add new citation type options for book, journal or periodical and online encyclopedia.

## Why was this needed?
See above. 

## Implementation notes
See also #7331.

## Screenshots
N/A.

## Notes to reviewer
I am not an experienced coder.